### PR TITLE
Sallitaan sama tutkintonimikeryhmä muodostumisessa

### DIFF
--- a/eperusteet/eperusteet-service/src/main/java/fi/vm/sade/eperusteet/service/impl/PerusteServiceImpl.java
+++ b/eperusteet/eperusteet-service/src/main/java/fi/vm/sade/eperusteet/service/impl/PerusteServiceImpl.java
@@ -15,7 +15,6 @@
  */
 package fi.vm.sade.eperusteet.service.impl;
 
-import com.google.common.base.Strings;
 import fi.vm.sade.eperusteet.domain.*;
 import fi.vm.sade.eperusteet.domain.tutkinnonosa.TutkinnonOsa;
 import fi.vm.sade.eperusteet.domain.tutkinnonrakenne.AbstractRakenneOsa;
@@ -1071,7 +1070,7 @@ public class PerusteServiceImpl implements PerusteService, ApplicationListener<P
 
         // Käytetään perusteen metatietoihin liitettyjä tutkintonimikekoodiliitoksia validointiin
         List<TutkintonimikeKoodiDto> tutkintonimikeTutkinnonOsaLiitokset = tutkintonimikeKoodit.stream()
-                .filter(tk -> !Strings.isNullOrEmpty(tk.getTutkinnonOsaUri()) && !Strings.isNullOrEmpty(tk.getTutkintonimikeUri()))
+                .filter(tk -> StringUtils.isNotEmpty(tk.getTutkinnonOsaUri()) && StringUtils.isNotEmpty(tk.getTutkintonimikeUri()))
                 .collect(Collectors.toList());
 
         for (TutkintonimikeKoodiDto tk : tutkintonimikeTutkinnonOsaLiitokset) {
@@ -1094,7 +1093,7 @@ public class PerusteServiceImpl implements PerusteService, ApplicationListener<P
                             .filter(osa -> osa instanceof RakenneOsaDto)
                             .map(osa -> ((RakenneOsaDto) osa).getTutkinnonOsaViite())
                             .map(tovToKoodiUriMap::get)
-                            .filter(x -> !Strings.isNullOrEmpty(x))
+                            .filter(StringUtils::isNotEmpty)
                             .collect(Collectors.toSet());
 
                     if (!moduulinVaaditutKoodit.removeAll(tutkinnonOsaKoodit)) {

--- a/eperusteet/eperusteet-service/src/test/java/fi/vm/sade/eperusteet/service/PerusteenRakenneIT.java
+++ b/eperusteet/eperusteet-service/src/test/java/fi/vm/sade/eperusteet/service/PerusteenRakenneIT.java
@@ -106,13 +106,17 @@ public class PerusteenRakenneIT extends AbstractIntegrationTest {
         return updated;
     }
 
-    private TutkinnonOsaViiteDto uusiTutkinnonOsa() {
+    private TutkinnonOsaViiteDto uusiTutkinnonOsa(TutkinnonOsaDto tosaDto) {
         TutkinnonOsaViiteDto result = perusteService.addTutkinnonOsa(peruste.getId(), suoritustapa.getSuoritustapakoodi(), TutkinnonOsaViiteDto.builder()
                 .tyyppi(TutkinnonOsaTyyppi.NORMAALI)
-                .tutkinnonOsaDto(TutkinnonOsaDto.builder()
-                        .build())
+                .tutkinnonOsaDto(tosaDto)
                 .build());
         return result;
+    }
+
+    private TutkinnonOsaViiteDto uusiTutkinnonOsa() {
+        return uusiTutkinnonOsa(TutkinnonOsaDto.builder()
+                        .build());
     }
 
     @Test
@@ -254,6 +258,62 @@ public class PerusteenRakenneIT extends AbstractIntegrationTest {
         List<TilaUpdateStatus.Status> infot = status.getInfot();
         assertThat(status.getInfot().stream().map(TilaUpdateStatus.Status::getViesti))
             .doesNotContain("tutkintonimikkeen-osaamisala-puuttuu-perusteesta");
+    }
+
+    // Relates:
+    // - EP-1533
+    @Test
+    @Rollback
+    public void testDuplikaatitTutkintonimikkeetEriTutkinnonOsalla() {
+        perusteService.addTutkintonimikeKoodi(peruste.getId(), TutkintonimikeKoodiDto.builder()
+                .tutkinnonOsaArvo("1")
+                .tutkinnonOsaUri("tutkinnonosa_1")
+                .tutkintonimikeArvo("1")
+                .tutkintonimikeUri("tutkintonimike_1").build());
+
+        perusteService.addTutkintonimikeKoodi(peruste.getId(), TutkintonimikeKoodiDto.builder()
+                .tutkinnonOsaArvo("2")
+                .tutkinnonOsaUri("tutkinnonosa_2")
+                .tutkintonimikeArvo("1")
+                .tutkintonimikeUri("tutkintonimike_1").build());
+
+        TutkinnonOsaViiteDto a = uusiTutkinnonOsa(TutkinnonOsaDto.builder()
+                .koodi(KoodiDto.of("tutkinnonosa", "1"))
+            .build());
+
+        TutkinnonOsaViiteDto b = uusiTutkinnonOsa(TutkinnonOsaDto.builder()
+                .koodi(KoodiDto.of("tutkinnonosa", "2"))
+                .build());
+
+        RakenneModuuliDto rakenneDto = getRakenneDto();
+        rakenneDto.setOsat(new ArrayList<>(Arrays.asList(
+                RakenneModuuliDto.builder()
+                        .rooli(RakenneModuuliRooli.TUTKINTONIMIKE)
+                        .tutkintonimike(KoodiDto.of("tutkintonimike", "1"))
+                        .osat(Collections.singletonList(RakenneOsaDto.of(a)))
+                        .build(),
+                RakenneModuuliDto.builder()
+                        .rooli(RakenneModuuliRooli.TUTKINTONIMIKE)
+                        .tutkintonimike(KoodiDto.of("tutkintonimike", "1"))
+                        .osat(Collections.singletonList(RakenneOsaDto.of(b)))
+                        .build())));
+
+        assertThatCode(() -> update(rakenneDto))
+                .doesNotThrowAnyException();
+
+        TutkinnonOsaViiteDto c = uusiTutkinnonOsa(TutkinnonOsaDto.builder()
+                .koodi(KoodiDto.of("tutkinnonosa", "2"))
+                .build());
+
+        rakenneDto.getOsat()
+                .add(RakenneModuuliDto.builder()
+                        .rooli(RakenneModuuliRooli.TUTKINTONIMIKE)
+                        .tutkintonimike(KoodiDto.of("tutkintonimike", "1"))
+                        .osat(Collections.singletonList(RakenneOsaDto.of(c)))
+                        .build());
+
+        assertThatCode(() -> update(rakenneDto))
+                .hasMessage("tutkintonimikeryhmalle-maaritetty-tutkinnon-osa-useaan-kertaan");
     }
 
     @Test


### PR DESCRIPTION
- Ryhmien tutkinnon osien liitokset voivat olla vain kerran yhdessä
  ryhmässä
- Jokainen metadatassa oleva liitoskoodi on löydyttävä ryhmistä